### PR TITLE
Fix #37: Add .md extension if name contains md word

### DIFF
--- a/doc/copy-md-example-to-readme.py
+++ b/doc/copy-md-example-to-readme.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python3
 
-from mdutils.fileutils.fileutils import MarkDownFile
+from mdutils.fileutils.fileutils import MarkdownFile
 from pathlib import Path
 
 
 readme_path = "../README.md"
-readme_content = MarkDownFile.read_file(readme_path)
-readme = MarkDownFile(readme_path)
-markdown_example = MarkDownFile.read_file("./source/examples/Example_Markdown.md")
+readme_content = MarkdownFile.read_file(readme_path)
+readme = MarkdownFile(readme_path)
+markdown_example = MarkdownFile.read_file("./source/examples/Example_Markdown.md")
 replace_index = readme_content.find("Markdown File Example\n=====================")
 new_readme = readme_content[:replace_index] + markdown_example
-readme.rewrite_all_file(new_readme)
+readme.write(new_readme)
 

--- a/mdutils/fileutils/__init__.py
+++ b/mdutils/fileutils/__init__.py
@@ -1,1 +1,1 @@
-from mdutils.fileutils.fileutils import MarkDownFile
+from mdutils.fileutils.fileutils import MarkdownFile

--- a/mdutils/fileutils/fileutils.py
+++ b/mdutils/fileutils/fileutils.py
@@ -7,7 +7,7 @@
 # MIT License: (C) 2018 Dídac Coll
 
 
-class MarkDownFile(object):
+class MarkdownFile(object):
     """MarkDownFile class creates a new file of MarkDown extension.
 
     Features available are:
@@ -19,18 +19,18 @@ class MarkDownFile(object):
         """Creates a markdown file, if name is not empty.
         :param str name: file name"""
         if name:
-            self.file_name = name if 'md' in name else name + '.md'
+            self.file_name = name if name.endswith('.md') else name + '.md'
             self.file = open(self.file_name, 'w+', encoding='UTF-8')
             self.file.close()
 
-    def rewrite_all_file(self, data):
+    def write(self, data):
         """Rewrite all the data of a Markdown file by ``data``.
 
         :param str data: is a string containing all the data that is written in the markdown file."""
         with open(self.file_name, 'w', encoding='utf-8') as self.file:
             self.file.write(data)
 
-    def append_end(self, data):
+    def append(self, data):
         """Write at the last position of a Markdown file.
 
         :param str data: is a string containing all the data that is written in the markdown file."""
@@ -69,5 +69,5 @@ class MarkDownFile(object):
 
 
 if __name__ == '__main__':
-    new_file = MarkDownFile('Example')
-    new_file.rewrite_all_file(data="# Some Text Example")
+    new_file = MarkdownFile('Example')
+    new_file.write(data="# Some Text Example")

--- a/mdutils/mdutils.py
+++ b/mdutils/mdutils.py
@@ -20,7 +20,7 @@ The available features are:
 """
 import mdutils.tools.Table
 import mdutils.tools.TableOfContents
-from mdutils.fileutils.fileutils import MarkDownFile
+from mdutils.fileutils.fileutils import MarkdownFile
 from mdutils.tools.Header import Header
 from mdutils.tools.Image import Image
 from mdutils.tools.Link import Inline, Reference
@@ -67,8 +67,8 @@ class MdUtils:
     def create_md_file(self):
         """It creates a new Markdown file.
         :return: return an instance of a MarkDownFile."""
-        md_file = MarkDownFile(self.file_name)
-        md_file.rewrite_all_file(
+        md_file = MarkdownFile(self.file_name)
+        md_file.write(
             data=self.title + self.table_of_contents + self.file_data_text + self.reference.get_references_as_markdown()
         )
         return md_file
@@ -81,7 +81,7 @@ class MdUtils:
         :return: optionally returns the file data content.
         :rtype: str
         """
-        file_data = MarkDownFile().read_file(file_name)
+        file_data = MarkdownFile().read_file(file_name)
         self.___update_file_data(file_data)
 
         return file_data

--- a/tests/test_fileutils/test_fileutils.py
+++ b/tests/test_fileutils/test_fileutils.py
@@ -1,0 +1,75 @@
+# Python
+#
+# This module implements tests for MdUtils class.
+#
+# This file is part of mdutils. https://github.com/didix21/mdutils
+#
+# MIT License: (C) 2020 Dídac Coll
+
+from unittest import TestCase
+from mdutils.fileutils import MarkdownFile
+import tempfile
+import os
+
+
+class TestMarkdownFile(TestCase):
+
+    def test_create_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            file = MarkdownFile('Test_file')
+            self.assertEqual(file.file_name, 'Test_file.md')
+
+    def test_create_file_case_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            file = MarkdownFile('Test_filemd')
+            self.assertEqual(file.file_name, 'Test_filemd.md')
+
+    def test_create_file_case_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            file = MarkdownFile('Test_file.md')
+            self.assertEqual(file.file_name, 'Test_file.md')
+
+    def test_write(self):
+        expected_content = "Write some content"
+        file_name = 'Test_file.md'
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            file = MarkdownFile(file_name)
+            file.write(expected_content)
+            with open(file_name, 'r') as actual_md:
+                self.assertEqual(actual_md.read(), expected_content)
+
+    def test_append(self):
+        expected_content = "Write some content and some data"
+        file_name = 'Test_file.md'
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            file = MarkdownFile(file_name)
+            file.write("Write some content")
+            file.append(" and some data")
+            with open(file_name, 'r') as actual_md:
+                self.assertEqual(actual_md.read(), expected_content)
+
+    def test_append_second_line(self):
+        expected_content = "This is the 1st line\nThis is the 2nd line\nThis is the 3th line\nThis is the 4th line"
+        file_name = 'Test_file.md'
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            file = MarkdownFile(file_name)
+            file.write("This is the 1st line\nThis is the 2nd line\nThis is the 4th line")
+            file.append_after_second_line("This is the 3th line")
+            with open(file_name, 'r') as actual_md:
+                self.assertEqual(actual_md.read(), expected_content)
+
+    def test_read(self):
+        expected_content = "This is the expected content after reading the file"
+        file_name = 'Test_file.md'
+        with tempfile.TemporaryDirectory() as tmp:
+            os.chdir(tmp)
+            with open(file_name, 'w') as file:
+                file.write(expected_content)
+
+            self.assertEqual(MarkdownFile.read_file(file_name), expected_content)

--- a/tests/test_mdutils.py
+++ b/tests/test_mdutils.py
@@ -8,7 +8,7 @@
 
 from unittest import TestCase
 from mdutils.mdutils import MdUtils
-from mdutils.fileutils import MarkDownFile
+from mdutils.fileutils import MarkdownFile
 
 from pathlib import Path
 import os
@@ -325,7 +325,7 @@ class TestMdUtils(TestCase):
 
         md_file.create_md_file()
 
-        created_data = MarkDownFile.read_file('Test_file.md')
+        created_data = MarkdownFile.read_file('Test_file.md')
 
         self.assertEqual(expected_value, created_data)
 
@@ -361,7 +361,7 @@ class TestMdUtils(TestCase):
         md_file.new_line(image_2)
         md_file.create_md_file()
 
-        actual_created_data = MarkDownFile.read_file("Test_file")
+        actual_created_data = MarkdownFile.read_file("Test_file")
 
         self.assertEqual(expected_created_data, actual_created_data)
 
@@ -370,18 +370,18 @@ class TestMdUtils(TestCase):
         md_file.new_list(self.complex_items)
         md_file.create_md_file()
 
-        self.assertEqual(self.expected_list, MarkDownFile.read_file('Test_file.md'))
+        self.assertEqual(self.expected_list, MarkdownFile.read_file('Test_file.md'))
 
     def test_new_checkbox_list(self):
         md_file = MdUtils(file_name="Test_file", title="")
         md_file.new_checkbox_list(self.complex_items)
         md_file.create_md_file()
 
-        self.assertEqual(self.expected_list.replace('-', '- [ ]'), MarkDownFile.read_file('Test_file.md'))
+        self.assertEqual(self.expected_list.replace('-', '- [ ]'), MarkdownFile.read_file('Test_file.md'))
 
     def test_new_checkbox_checked_list(self):
         md_file = MdUtils(file_name="Test_file", title="")
         md_file.new_checkbox_list(self.complex_items, checked=True)
         md_file.create_md_file()
 
-        self.assertEqual(self.expected_list.replace('-', '- [x]'), MarkDownFile.read_file('Test_file.md'))
+        self.assertEqual(self.expected_list.replace('-', '- [x]'), MarkdownFile.read_file('Test_file.md'))


### PR DESCRIPTION
- Add unittest for fileutils.
- Rename MarkDownFile to MarkdownFile.
- Rename rewrite_all_file to write.
- Rename append_end to append.