### PR TITLE
make text_align be a list not only str or None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='mdutils',
-      version='1.3.0',
+      version='1.3.0.1',
       license='MIT',
       author='Didac Coll',
       author_email='didaccoll_93@hotmail.com',


### PR DESCRIPTION
Hi,
This is a patch extending text_align in Table.py to a list (str or None are still possible types). In such a way, an individual alignment for each column can be set.

Hoping it helps,
Best,
Serguei.

Signed-off-by: Serguei Sokol <sokol@insa-toulouse.fr>