### PR TITLE
Modify tests to fix flakiness

### DIFF
--- a/mdutils/fileutils/fileutils.py
+++ b/mdutils/fileutils/fileutils.py
@@ -15,33 +15,35 @@ class MarkDownFile(object):
         - Rewrite a file with new data.
         - Write at the end of the file."""
 
-    def __init__(self, name=''):
+    def __init__(self, name='', tmp=''):
         """Creates a markdown file, if name is not empty.
         :param str name: file name"""
+        import os
         if name:
+            self.dirname = tmp if tmp else os.getcwd() 
             self.file_name = name if name.endswith('.md') else name + '.md'
-            self.file = open(self.file_name, 'w+', encoding='UTF-8')
+            self.file = open(f'{self.dirname}/{self.file_name}', 'w+', encoding='UTF-8')
             self.file.close()
 
     def rewrite_all_file(self, data):
         """Rewrite all the data of a Markdown file by ``data``.
 
         :param str data: is a string containing all the data that is written in the markdown file."""
-        with open(self.file_name, 'w', encoding='utf-8') as self.file:
+        with open(f'{self.dirname}/{self.file_name}', 'w', encoding='utf-8') as self.file:
             self.file.write(data)
 
     def append_end(self, data):
         """Write at the last position of a Markdown file.
 
         :param str data: is a string containing all the data that is written in the markdown file."""
-        with open(self.file_name, 'a', encoding='utf-8') as self.file:
+        with open(f'{self.dirname}/{self.file_name}', 'a', encoding='utf-8') as self.file:
             self.file.write(data)
 
     def append_after_second_line(self, data):
         """Write after the file's first line.
 
         :param str data: is a string containing all the data that is written in the markdown file."""
-        with open(self.file_name, 'r+', encoding='utf-8') as self.file:
+        with open(f'{self.dirname}/{self.file_name}', 'r+', encoding='utf-8') as self.file:
             file_data = self.file.read()  # Save all the file's content
             self.file.seek(0, 0)  # Place file pointer at the beginning
             first_line = self.file.readline()  # Read the first line

--- a/tests/test_fileutils/test_fileutils.py
+++ b/tests/test_fileutils/test_fileutils.py
@@ -16,60 +16,53 @@ class TestMarkdownFile(TestCase):
 
     def test_create_file(self):
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            file = MarkDownFile('Test_file')
+            file = MarkDownFile('Test_file', tmp)
             self.assertEqual(file.file_name, 'Test_file.md')
 
     def test_create_file_case_0(self):
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            file = MarkDownFile('Test_filemd')
+            file = MarkDownFile('Test_filemd', tmp)
             self.assertEqual(file.file_name, 'Test_filemd.md')
 
     def test_create_file_case_1(self):
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            file = MarkDownFile('Test_file.md')
+            file = MarkDownFile('Test_file.md', tmp)
             self.assertEqual(file.file_name, 'Test_file.md')
 
     def test_rewrite_all_file(self):
         expected_content = "Write some content"
         file_name = 'Test_file.md'
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            file = MarkDownFile(file_name)
+            file = MarkDownFile(file_name, tmp)
             file.rewrite_all_file(expected_content)
-            with open(file_name, 'r') as actual_md:
+            with open(f'{tmp}/{file_name}', 'r') as actual_md:
                 self.assertEqual(actual_md.read(), expected_content)
 
     def test_append_end(self):
         expected_content = "Write some content and some data"
         file_name = 'Test_file.md'
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            file = MarkDownFile(file_name)
+            file = MarkDownFile(file_name, tmp)
             file.rewrite_all_file("Write some content")
             file.append_end(" and some data")
-            with open(file_name, 'r') as actual_md:
+            with open(f'{tmp}/{file_name}', 'r') as actual_md:
                 self.assertEqual(actual_md.read(), expected_content)
 
     def test_append_second_line(self):
         expected_content = "This is the 1st line\nThis is the 2nd line\nThis is the 3th line\nThis is the 4th line"
         file_name = 'Test_file.md'
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            file = MarkDownFile(file_name)
+            file = MarkDownFile(file_name, tmp)
             file.rewrite_all_file("This is the 1st line\nThis is the 2nd line\nThis is the 4th line")
             file.append_after_second_line("This is the 3th line")
-            with open(file_name, 'r') as actual_md:
+            with open(f'{tmp}/{file_name}', 'r') as actual_md:
                 self.assertEqual(actual_md.read(), expected_content)
 
     def test_read(self):
         expected_content = "This is the expected content after reading the file"
         file_name = 'Test_file.md'
         with tempfile.TemporaryDirectory() as tmp:
-            os.chdir(tmp)
-            with open(file_name, 'w') as file:
+            with open(f'{tmp}/{file_name}', 'w') as file:
                 file.write(expected_content)
 
-            self.assertEqual(MarkDownFile.read_file(file_name), expected_content)
+            self.assertEqual(MarkDownFile.read_file(f'{tmp}/{file_name}'), expected_content)


### PR DESCRIPTION
Multiple tests inside [`test_mdutils.py`](https://github.com/didix21/mdutils/blob/master/tests/test_mdutils.py) were found to be flaky, i.e. tests that both pass and fail despite no changes to the code or the tests itself. 

Using the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin, when the tests were re-run more than once, multiple tests inside [`test_mdutils.py`](https://github.com/didix21/mdutils/blob/master/tests/test_mdutils.py) were failing. Upon looking at the code, the reason was because the working directory was being changed due to the various calls to `os.chdir(tmp)` inside [`test_fileutils.py`](https://github.com/didix21/mdutils/blob/master/tests/test_fileutils/test_fileutils.py). This meant the tests could not locate `Test_file.md` in the directory they were meant to be in.

To fix this, I just removed the calls to `os.chdir(tmp)` in [`test_fileutils.py`](https://github.com/didix21/mdutils/blob/master/tests/test_fileutils/test_fileutils.py) and modified  `MarkDownFile` inside [`fileutils.py`](https://github.com/didix21/mdutils/blob/master/mdutils/fileutils/fileutils.py) to include another parameter called `tmp`, which indicates whether or not the markdown file should be created in the temporary directory or not. If this is not empty, the code is modified in such a way that the temporary files are created in the temporary directory without calls to `os.chdir(tmp)`. This is done by including the entire path that the file is supposed to be in.

To reproduce:
1) Install `pytest-flakefinder` by following the instructions [here](https://github.com/dropbox/pytest-flakefinder). 
2) At root directory, run `pytest --flake-finder tests`

After implementing the fix, all tests pass successfully, both with and without the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin being used. 

In general, flaky tests are a pain to fix with regards to locating the root of the actual problem, so it's a good idea to fix them when you detect them. I'm aware that the tests might not be re-run at all, but this change makes the entire module more robust and future-proof so it's just a small fix for you to consider. 