### PR TITLE
[New feature] Introduce `header_id` as parameter for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ mdFile.new_header(level=4, title='Atx Header 4')
 mdFile.new_header(level=5, title='Atx Header 5')
 mdFile.new_header(level=6, title='Atx Header 6')
 ```
+
+To give a header an ID (Extended Markdown syntax only), the `header_id` parameter can be used:
+```python
+mdFile.new_header(level=1, title='Header', header_id='firstheader')
+```
+This will result in ``# Header {#firstheader}`` in the Markdown file.
+
 # Atx Header 1
 
 ## Atx Header 2

--- a/mdutils/mdutils.py
+++ b/mdutils/mdutils.py
@@ -93,7 +93,7 @@ class MdUtils:
 
         return file_data
 
-    def new_header(self, level, title, style='atx', add_table_of_contents='y'):
+    def new_header(self, level, title, style='atx', add_table_of_contents='y', header_id=''):
         """Add a new header to the Markdown file.
 
         :param level: Header level. *atx* style can take values 1 til 6 and *setext* style take values 1 and 2.
@@ -105,6 +105,8 @@ class MdUtils:
         :param add_table_of_contents: by default the atx and setext headers of level 1 and 2 are added to the \
         table of contents, setting this parameter to 'n'.
         :type add_table_of_contents: str
+        :param header_id: ID of the header for extended Markdown syntax
+        :type header_id: str
 
         :Example:
         >>> from mdutils import MdUtils
@@ -117,8 +119,8 @@ class MdUtils:
         """
         if add_table_of_contents == 'y':
             self.__add_new_item_table_of_content(level, title)
-        self.___update_file_data(self.header.choose_header(level, title, style))
-        return self.header.choose_header(level, title, style)
+        self.___update_file_data(self.header.choose_header(level, title, style, header_id))
+        return self.header.choose_header(level, title, style, header_id)
 
     def __add_new_item_table_of_content(self, level, item):
         """Automatically add new atx headers to the table of contents.

--- a/mdutils/tools/Header.py
+++ b/mdutils/tools/Header.py
@@ -25,70 +25,88 @@ class Header:
     # *                             Atx-Style                            *
     # ********************************************************************
     @staticmethod
-    def atx_level_1(title):
+    def atx_level_1(title, header_id=''):
         """Return a atx level 1 header.
 
         :param str title: text title.
+        :param header_id: ID of the header for extended Markdown syntax
         :return: a header title of form: ``'\\n#' + title + '\\n'``
         :rtype: str
         """
+        if len(header_id):
+            header_id = ' {#' + header_id + '}'
 
-        return '\n# ' + title + '\n'
+        return '\n# ' + title + header_id + '\n'
 
     @staticmethod
-    def atx_level_2(title):
+    def atx_level_2(title, header_id=''):
         """Return a atx level 2 header.
 
         :param str title: text title.
+        :param header_id: ID of the header for extended Markdown syntax
         :return: a header title of form: ``'\\n##' + title + '\\n'``
         :rtype: str
         """
+        if len(header_id):
+            header_id = ' {#' + header_id + '}'
 
-        return '\n## ' + title + '\n'
+        return '\n## ' + title + header_id + '\n'
 
     @staticmethod
-    def atx_level_3(title):
+    def atx_level_3(title, header_id=''):
         """Return a atx level 3 header.
 
         :param str title: text title.
+        :param header_id: ID of the header for extended Markdown syntax
         :return: a header title of form: ``'\\n###' + title + '\\n'``
         :rtype: str
         """
+        if len(header_id):
+            header_id = ' {#' + header_id + '}'
 
-        return '\n### ' + title + '\n'
+        return '\n### ' + title + header_id + '\n'
 
     @staticmethod
-    def atx_level_4(title):
+    def atx_level_4(title, header_id=''):
         """Return a atx level 4 header.
 
         :param str title: text title.
+        :param header_id: ID of the header for extended Markdown syntax
         :return: a header title of form: ``'\\n####' + title + '\\n'``
         :rtype: str
         """
+        if len(header_id):
+            header_id = ' {#' + header_id + '}'
 
-        return '\n#### ' + title + '\n'
+        return '\n#### ' + title + header_id + '\n'
 
     @staticmethod
-    def atx_level_5(title):
+    def atx_level_5(title, header_id=''):
         """Return a atx level 5 header.
 
         :param str title: text title.
+        :param header_id: ID of the header for extended Markdown syntax
         :return: a header title of form: ``'\\n#####' + title + '\\n'``
         :rtype: str
         """
+        if len(header_id):
+            header_id = ' {#' + header_id + '}'
 
-        return '\n##### ' + title + '\n'
+        return '\n##### ' + title + header_id + '\n'
 
     @staticmethod
-    def atx_level_6(title):
+    def atx_level_6(title, header_id=''):
         """Return a atx level 6 header.
 
         :param str title: text title.
+        :param header_id: ID of the header for extended Markdown syntax
         :return: a header title of form: ``'\\n######' + title + '\\n'``
         :rtype: str
         """
+        if len(header_id):
+            header_id = ' {#' + header_id + '}'
 
-        return '\n###### ' + title + '\n'
+        return '\n###### ' + title + header_id + '\n'
 
     # ********************************************************************
     # *                          Setext-Style                            *
@@ -142,7 +160,7 @@ class Header:
         return '[' + text + '](' + link + ')'
 
     @staticmethod
-    def choose_header(level, title, style='atx'):
+    def choose_header(level, title, style='atx', header_id=''):
         # noinspection SpellCheckingInspection
         """This method choose the style and the header level.
 
@@ -157,21 +175,22 @@ class Header:
                 :param level: Header Level, For Atx-style 1 til 6. For Setext-style 1 and 2 header levels.
                 :param title: Header Title.
                 :param style: Header Style atx or setext.
+                :param header_id: ID of the header for extended Markdown syntax
                 :return:
                 """
         if style.lower() == 'atx':
             if level == 1:
-                return Header.atx_level_1(title)
+                return Header.atx_level_1(title, header_id)
             elif level == 2:
-                return Header.atx_level_2(title)
+                return Header.atx_level_2(title, header_id)
             elif level == 3:
-                return Header.atx_level_3(title)
+                return Header.atx_level_3(title, header_id)
             elif level == 4:
-                return Header.atx_level_4(title)
+                return Header.atx_level_4(title, header_id)
             elif level == 5:
-                return Header.atx_level_5(title)
+                return Header.atx_level_5(title, header_id)
             elif level == 6:
-                return Header.atx_level_6(title)
+                return Header.atx_level_6(title, header_id)
             else:
                 raise ValueError("For 'atx' style, level's expected value: 1, 2, 3, 4, 5 or 6, but level = "
                                  + str(level))

--- a/tests/test_mdutils.py
+++ b/tests/test_mdutils.py
@@ -55,10 +55,14 @@ class TestMdUtils(TestCase):
         file_name = 'Test_file'
         md_file = MdUtils(file_name)
         string_headers_expected = "\n# Header 0\n\n## Header 1\n\n### Header 2\n\n#### Header 3\n\n" \
-                                  "##### Header 4\n\n###### Header 5\n"
+                                  "##### Header 4\n\n###### Header 5 {#header5}\n"
         string_headers = ""
         for x in range(6):
-            string_headers += md_file.new_header(level=(x + 1), title='Header ' + str(x), style='atx')
+            # The last header includes an ID
+            if x == 5:
+                string_headers += md_file.new_header(level=(x + 1), title='Header ' + str(x), style='atx', header_id='header5')
+            else:
+                string_headers += md_file.new_header(level=(x + 1), title='Header ' + str(x), style='atx')
 
         self.assertEqual(string_headers, string_headers_expected)
         md_file.create_md_file()

--- a/tests/test_tools/test_header.py
+++ b/tests/test_tools/test_header.py
@@ -14,33 +14,51 @@ class TestHeader(TestCase):
 
     def test_atx_level_1(self):
         title = "Text Title Atx 1"
+        header_id = "myheader"
         result = '\n# ' + title + '\n'
+        result2 = '\n# ' + title + ' {#myheader}' + '\n'
         self.assertEqual(Header().atx_level_1(title), result)
+        self.assertEqual(Header().atx_level_1(title, header_id), result2)
 
     def test_atx_level_2(self):
         title = "Text Title Atx 2"
+        header_id = "myheader"
         result = '\n## ' + title + '\n'
+        result2 = '\n## ' + title + ' {#myheader}' + '\n'
         self.assertEqual(Header().atx_level_2(title), result)
+        self.assertEqual(Header().atx_level_2(title, header_id), result2)
 
     def test_atx_level_3(self):
         title = "Text Title Atx 3"
+        header_id = "myheader"
         result = '\n### ' + title + '\n'
+        result2 = '\n### ' + title + ' {#myheader}' + '\n'
         self.assertEqual(Header().atx_level_3(title), result)
+        self.assertEqual(Header().atx_level_3(title, header_id), result2)
 
     def test_atx_level_4(self):
         title = "Text Title Atx 4"
+        header_id = "myheader"
         result = '\n#### ' + title + '\n'
+        result2 = '\n#### ' + title + ' {#myheader}' + '\n'
         self.assertEqual(Header().atx_level_4(title), result)
+        self.assertEqual(Header().atx_level_4(title, header_id), result2)
 
     def test_atx_level_5(self):
         title = "Text Title Atx 5"
+        header_id = "myheader"
         result = '\n##### ' + title + '\n'
+        result2 = '\n##### ' + title + ' {#myheader}' + '\n'
         self.assertEqual(Header().atx_level_5(title), result)
+        self.assertEqual(Header().atx_level_5(title, header_id), result2)
 
     def test_atx_level_6(self):
         title = "Text Title Atx 6"
+        header_id = "myheader"
         result = '\n###### ' + title + '\n'
+        result2 = '\n###### ' + title + ' {#myheader}' + '\n'
         self.assertEqual(Header().atx_level_6(title), result)
+        self.assertEqual(Header().atx_level_6(title, header_id), result2)
 
     def test_setext_level_1(self):
         title = "Text Title Setext 1"


### PR DESCRIPTION
Closes #77 
This PR adds the option to create atx-headers with an ID for extended Markdown Syntax.