### PR TITLE
GH-88: Automate release candidate

### DIFF
--- a/.github/actions/update-target-commitish/action.yml
+++ b/.github/actions/update-target-commitish/action.yml
@@ -1,0 +1,34 @@
+name: "Update target commitish"
+description: Update target commitish from a provided release
+inputs:
+  github_token: 
+    description: Provide github token
+    required: true
+  release_id: 
+    description: Provide a valid release id
+    required: true
+  target_commitish:
+    description: Provide the new target commitish
+    required: true
+  tag_name:
+    description: Provide the tag name
+    required: true
+
+runs: 
+  using: "composite" # This is mandatory if we want to share the action between workflows.
+  steps:
+    - name: 'Update target commitish ${{ inputs.target_commitish }}'
+      shell: bash
+      run: |
+          gh api repos/$REPOSITORY/releases/$RELEASE_ID \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -f target_commitish="$TARGET_COMMITISH" \
+            -f tag_name="$TAG_NAME"
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        REPOSITORY: ${{ github.repository }}
+        RELEASE_ID: ${{ inputs.release_id }}
+        TARGET_COMMITISH: ${{ inputs.target_commitish }}
+        TAG_NAME: ${{ inputs.tag_name }}
+        

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,80 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: "Get latest release draft"
+      uses: cardinalby/git-get-release-action@v1
+      id: latest_prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        latest: true
+        draft: true
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
+        pip install coverage
+        pip install -U pytest
+        pip install poetry
+
+    - name: Run unit tests
+      run: |
+        coverage run -m pytest
+        coverage xml
+
+    - name: Bump version on all needed files
+      run: |
+        ./scripts/update-release.py -v ${{ steps.latest_prerelease.outputs.tag_name }}
+
+    - name: "✏️ Generate release changelog"
+      uses: heinrichreimer/github-changelog-generator-action@v2.3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }} 
+    
+    - name: Check commit has been updated
+      run: |
+        git diff
+
+    - name: Build package
+      run: python setup.py sdist --formats=gztar,zip
+
+    - name: Upload binaries to release
+      uses: xresloader/upload-to-github-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        file: ./dist/*
+        draft: true
+        release_id: ${{ steps.latest_prerelease.outputs.id }}
+
+    - name: 'Bump version to ${{ steps.latest_prerelease.outputs.tag_name }}'
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "github-actions[bot]"
+        git commit -m "Bump version to ${{ steps.latest_prerelease.outputs.tag_name }}" -a
+    
+    - name: Push changes
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
+
+    - name: Update target commitish and publish release
+      uses: './.github/actions/update-target-commitish'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        release_id:  ${{ steps.latest_prerelease.outputs.id }}
+        target_commitish: "refs/heads/master"
+        tag_name: ${{ steps.latest_prerelease.outputs.tag_name }}

--- a/scripts/update-release.py
+++ b/scripts/update-release.py
@@ -63,6 +63,10 @@ def main():
         else:
             assert False, "Unhandled option"
 
+    if not version:
+        usage()
+        sys.exit(2)
+
     version_number = version[1:] if "v" in version else version
     replace_version_on_setup_py(version_number)
     replace_version_on_config_py(version_number)


### PR DESCRIPTION
- Create a new action for creating a new release candidate.
- It will update the latest draft version on files: setup.py,
  pyproject.toml, .github_changelog_generator, doc/source/conf.py.
- Generate tar and zip distribution.
- Upload to the release draft.
- Add new action for updating target_commitish to "ref/head/master".
- Commit changes on master and push them.
