### PR TITLE
Fix #95: blank lines at the beginning of a file

### DIFF
--- a/mdutils/mdutils.py
+++ b/mdutils/mdutils.py
@@ -58,7 +58,7 @@ class MdUtils:
         self.file_name = file_name
         self.author = author
         self.textUtils = TextUtils
-        self.title = str(Header(level=1, title=title, style=HeaderStyle.SETEXT))
+        self.title = "" if title == "" else str(Header(level=1, title=title, style=HeaderStyle.SETEXT)) 
         self.table_of_contents = ""
         self.file_data_text = ""
         self._table_titles = []


### PR DESCRIPTION
Addressing Issue #95.

- Updated MdUtils.__init__ to accommodate for blank title so that it doesn't create unnecessary blank line breaks.

#95 was able to be fixed by not creating Header object when no title string was given.