### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/mdutils/mdutils.py
+++ b/mdutils/mdutils.py
@@ -338,11 +338,11 @@ class MdUtils:
 
         if bold_italics_code or color != "black" or align:
             self.___update_file_data(
-                "  \n"
+                "\n"
                 + self.textUtils.text_format(text, bold_italics_code, color, align)
             )
         else:
-            self.___update_file_data("  \n" + text)
+            self.___update_file_data("\n" + text)
 
         return self.file_data_text
 


### PR DESCRIPTION
MD best practices state that there might be no trailing spaces at the end of a line (or in an empty string line). So, I believe it would be better to remove them.