### PR TITLE
Remove extra spaces added by new_line()

### DIFF
--- a/mdutils/mdutils.py
+++ b/mdutils/mdutils.py
@@ -338,11 +338,11 @@ class MdUtils:
 
         if bold_italics_code or color != "black" or align:
             self.___update_file_data(
-                "  \n"
+                "\n"
                 + self.textUtils.text_format(text, bold_italics_code, color, align)
             )
         else:
-            self.___update_file_data("  \n" + text)
+            self.___update_file_data("\n" + text)
 
         return self.file_data_text
 

--- a/tests/test_mdutils.py
+++ b/tests/test_mdutils.py
@@ -207,7 +207,7 @@ class TestMdUtils(TestCase):
         created_value = md_file.new_line(
             "This is a new line created using new_line method."
         )
-        expected_value = "  \nThis is a new line created using new_line method."
+        expected_value = "\nThis is a new line created using new_line method."
         self.assertEqual(created_value, expected_value)
 
     def test_wrap_text(self):
@@ -217,7 +217,7 @@ class TestMdUtils(TestCase):
             wrap_width=25,
         )
         expected_value = (
-            "  \nThis is a new line \ncreated using new_line \nmethod with wrapping."
+            "\nThis is a new line \ncreated using new_line \nmethod with wrapping."
         )
         self.assertEqual(created_value, expected_value)
 
@@ -465,8 +465,8 @@ class TestMdUtils(TestCase):
 
         expected_created_data = (
             "\n\n\n"
-            "  \n{}".format(expected_image_1)
-            + "  \n{}".format(expected_image_2)
+            "\n{}".format(expected_image_1)
+            + "\n{}".format(expected_image_2)
             + "\n\n\n"
             "[image_2]: ../image_2.png\n"
             "[reference]: ../image.png\n"


### PR DESCRIPTION
Appears `new_line()` is adding extra unneeded spaces