### PR TITLE
fix: add IDE support for List argument of text_align in new_table

### DIFF
--- a/mdutils/mdutils.py
+++ b/mdutils/mdutils.py
@@ -206,7 +206,7 @@ class MdUtils:
         columns: int,
         rows: int,
         text: List[str],
-        text_align: str = "center",
+        text_align: Optional[Union[str, list]] = "center",
         marker: str = "",
     ) -> str:
         """This method takes a list of strings and creates a table.


### PR DESCRIPTION
`new_table` function is already functioning when using list args but the IDE, linter throws a false alarm when using list argument.

This PR add support for IDE, linter to accept List argument of `text_align` in `new_table`

- `new_table` function uses `Table` class to create a new table
- `Table` class already support a union type of `List` and `str`
- Only changing the function signature to not throw a warning/error when using list